### PR TITLE
Update check_markdown.yml

### DIFF
--- a/.github/workflows/check_markdown.yml
+++ b/.github/workflows/check_markdown.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: urls-checker
-        uses: urlstechie/urlchecker-action@0.2.1
+        uses: urlstechie/urlchecker-action@0.0.27
         with:
           file_types: .md
           print_all: false


### PR DESCRIPTION
We are going to be deprecating older versions of urlchecker (and there was a change in versioning to match the upstream package so the version only appears earlier) so I wanted to update here to make sure your workflows do not break! To be clear, 0.0.27 is actually the newest release. https://github.com/urlstechie/urlchecker-action/releases/tag/0.0.27

The updated versions also run about 7x as fast, so that's an added bonus!